### PR TITLE
Fix digital option formula and plotting text

### DIFF
--- a/pricing/asian_option.py
+++ b/pricing/asian_option.py
@@ -99,7 +99,7 @@ def plot_monte_carlo_paths(paths: np.ndarray):
     for i in range(n_paths):
         ax.plot(time_grid, paths[i], lw=0.8, alpha=0.7)
 
-    ax.set_title(f"Monte Carlo Simulated Paths (n=n_paths))")
+    ax.set_title(f"Monte Carlo Simulated Paths (n={n_paths})")
     ax.set_xlabel("Time (normalized)")
     ax.set_ylabel("Asset Price")
     ax.grid(True)

--- a/pricing/models/digital_black_scholes.py
+++ b/pricing/models/digital_black_scholes.py
@@ -2,8 +2,10 @@ import numpy as np
 from scipy.stats import norm
 
 def digital_cash_or_nothing(option_type, S, K, T, r, sigma, Q=1.0):
-    d2 = (np.log(S / K) + (r - 0.5 * sigma**2) * T) / (sigma * np.sqrt(T))
-    d2 -= sigma * np.sqrt(T)
+    """Price a cash-or-nothing digital option using Black-Scholes."""
+    # Compute the standard Black-Scholes d1/d2 terms
+    d1 = (np.log(S / K) + (r + 0.5 * sigma ** 2) * T) / (sigma * np.sqrt(T))
+    d2 = d1 - sigma * np.sqrt(T)
     if option_type.lower() == "call":
         return Q * np.exp(-r * T) * norm.cdf(d2)
     elif option_type.lower() == "put":


### PR DESCRIPTION
## Summary
- correct `digital_cash_or_nothing` implementation
- fix the title formatting in Asian option path plot

## Testing
- `python -m py_compile pricing/models/digital_black_scholes.py pricing/asian_option.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_683f6f2c0594832fa90efc74e5d93f9d