### PR TITLE
Apply global theme to About page

### DIFF
--- a/about_me.py
+++ b/about_me.py
@@ -1,12 +1,25 @@
 import streamlit as st
 import streamlit.components.v1 as components
-from styles.app_styles import load_theme
+from styles.app_styles import (
+    load_theme,
+    apply_global_styles,
+    get_component_styles,
+)
 
 def about_me_tab():
     """Professional About Me page with integrated styling"""
-    
-    # Load the theme to ensure consistent styling
+
+    # Configure page and load global styles
+    st.set_page_config(
+        page_title="About Me",
+        page_icon="👋",
+        layout="wide",
+        initial_sidebar_state="expanded",
+    )
+
     load_theme()
+    apply_global_styles()
+    st.markdown(get_component_styles(), unsafe_allow_html=True)
     
     # Page header with animation
     st.markdown("""


### PR DESCRIPTION
## Summary
- import and apply global style helpers in `about_me.py`
- set page configuration, apply global styles and component styles for consistency

## Testing
- `python -m py_compile about_me.py`

------
https://chatgpt.com/codex/tasks/task_e_6856200080cc832fad208aa332ae098f