### PR TITLE
Fix duplicate greek_type key

### DIFF
--- a/tabs/interest_rate_instruments.py
+++ b/tabs/interest_rate_instruments.py
@@ -758,7 +758,9 @@ def _greeks_analysis_tab():
         </div>
         """, unsafe_allow_html=True)
 
-        greek_type1 = st.selectbox("Greek to analyze", ["price", "delta", "vega", "rho"], key="greek_type")
+        greek_type1 = st.selectbox(
+            "Greek to analyze", ["price", "delta", "vega", "rho"], key="ir_greek_type"
+        )
         option_type = st.radio("Option type", ["call", "put"], key="greek_opt_type")
         model_type = st.radio("Calculation method", ["Analytical", "Monte Carlo"], key="greek_model")
 


### PR DESCRIPTION
## Summary
- resolve duplicate `greek_type` key error on the Interest Rate Instruments tab

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856bb723fa0832f8f1e0d9c7599bdee