### PR TITLE
Clarify FX rate orientation

### DIFF
--- a/pricing/models/swaps/market_data.py
+++ b/pricing/models/swaps/market_data.py
@@ -54,17 +54,17 @@ class MarketDataManager:
         except Exception as e:
             return self._get_fallback_overview()
     
-    def get_live_fx_rate(self, base_currency, quote_currency):
-        """Get live FX rate and statistics"""
+    def get_live_fx_rate(self, from_currency: str, to_currency: str):
+        """Get live FX rate for converting from ``from_currency`` into ``to_currency``."""
         if not YFINANCE_AVAILABLE:
             return {'rate': 1.0, 'change': 0.0, 'volatility': 15.0}
-        
-        cache_key = f"fx_{base_currency}{quote_currency}"
+
+        cache_key = f"fx_{from_currency}{to_currency}"
         if self._is_cached(cache_key):
             return self.cache[cache_key]['data']
-        
+
         try:
-            symbol = f"{base_currency}{quote_currency}=X"
+            symbol = f"{from_currency}{to_currency}=X"
             ticker = yf.Ticker(symbol)
             hist = ticker.history(period="30d")
             

--- a/tabs/swaps.py
+++ b/tabs/swaps.py
@@ -258,7 +258,10 @@ def currency_swaps_interface():
             return
         
         # Live FX data
-        fx_data = market_data_manager.get_live_fx_rate(quote_currency, base_currency)
+        fx_data = market_data_manager.get_live_fx_rate(
+            from_currency=quote_currency,
+            to_currency=base_currency,
+        )
         
         st.markdown(f"""
         <div class="success-box">


### PR DESCRIPTION
## Summary
- clarify fx rate orientation in `get_live_fx_rate`
- use named parameters when calling the fx function

## Testing
- `python -m compileall -q .`
- `flake8 pricing/models/swaps/market_data.py tabs/swaps.py | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_6856fb890c38832f9309a5544b2a3cba